### PR TITLE
added macos homebrew location of sdl2 lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ FIND_PATH( SDL2_INCLUDE_DIRS
 		SDL.h
 	PATHS
 		dependencies/SDL2
+        /usr/local/opt/sdl2/include/SDL2
 	PATH_SUFFIXES
 		include
 	DOC
@@ -37,6 +38,7 @@ FIND_LIBRARY( SDL2_LIBRARIES
 		SDL2 SDL2main
 	PATHS
 		dependencies/SDL2
+        /usr/local/opt/sdl2/lib
 	PATH_SUFFIXES
 		lib
 		lib64


### PR DESCRIPTION
SDL2 installs on macOS via [Homebrew](https://brew.sh/) to /usr/local/opt/sdl2; added that location to CMakeLists.txt.

Assortment of other issues still present on macOS.